### PR TITLE
Decrease run time up to 70%

### DIFF
--- a/powermenu.sh
+++ b/powermenu.sh
@@ -27,12 +27,21 @@ y="${DISPLAY_INFO[y]}"
 width=${DISPLAY_INFO["width"]}
 height="${DISPLAY_INFO[height]}"
 
-# Fake blurred background
-SS_PATH="$HOME/.config/rofi/screenshot"
-rm -f "${SS_PATH}.jpg"
-scrot -a $x,$y,$width,$height "${SS_PATH}.jpg"                 # screenshot
-convert "${SS_PATH}.jpg" -blur 0x10 -auto-level "${SS_PATH}.jpg"    # blur
-convert "${SS_PATH}.jpg" "${SS_PATH}.png"                           # rofi reads png images
+# Prepare screenshot path
+config_dir=${HOME}/.config/rofi
+mkdir -p "${config_dir}"
+SS_PATH=${config_dir}/screenshot
+rm -f "${SS_PATH}.jpg" && rm -f "${SS_PATH}.png"
+
+# Take screenshot
+scrot -a $x,$y,$width,$height "${SS_PATH}.jpg"
+
+# Simulate blur effect
+convert "${SS_PATH}.jpg" -scale 2.5% -resize 4000% "${SS_PATH}.jpg"
+
+# Rofi reads png images.
+# I found faster to first "blur" the image and then convert it to png
+convert "${SS_PATH}.jpg" "${SS_PATH}.png"
 
 # Compute font size based on display dimensions
 DEFAULT_WIDTH=1920


### PR DESCRIPTION
Applying a default blur effect is painfully slow, here's the timing of 100 runs, just before rofi is triggered:

![times before the change](https://user-images.githubusercontent.com/22058572/168490566-787c2460-c5f0-4e32-a7e1-b1de74aa2bf8.png)

I decreased the runtime up to 70% (65% average) by scaling down the image and then scaling it up to fill the screen, thus simulating a blur effect.

![times after the change](https://user-images.githubusercontent.com/22058572/168490705-f3d57ce6-380e-44fa-83e2-b35d68cb54dd.png)

The outcome is very similar to a common blur effect; I would say it is indistinguishable for the purposes of this project.

With a "normal" blur (before this change):

![blur-default](https://user-images.githubusercontent.com/22058572/168491571-44f353ed-8460-4d06-b182-d71faaae6fb7.jpg)


With simulated blur (after this change):

![blur-simulated](https://user-images.githubusercontent.com/22058572/168491587-471b095c-46b7-4938-b678-35d4e34ae0f2.jpg)


